### PR TITLE
CSV connection implemented

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
     <!-- Required for HR sensor -->
     <uses-permission android:name="android.permission.BODY_SENSORS" />
 
+     <!-- Needed permission for accessing Internet -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/reidlab/frontend/data/HeartRateSessionManager.kt
+++ b/app/src/main/java/org/reidlab/frontend/data/HeartRateSessionManager.kt
@@ -1,0 +1,41 @@
+package org.reidlab.frontend.data
+
+import android.content.Context
+import java.io.File
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class HeartRateSessionManager(private val context: Context) {
+    private val recordedValues = mutableListOf<Double>()
+    private var startTime: Instant? = null
+    private val sessionId: String = UUID.randomUUID().toString()
+
+    fun startSession() {
+        recordedValues.clear()
+        startTime = Instant.now()
+    }
+
+    fun record(value: Double) {
+        recordedValues.add(value)
+    }
+
+    fun stopAndExportCsv(userId: Int = 1): File? {
+        val start = startTime ?: return null
+        if (recordedValues.isEmpty()) return null
+
+        val avg = recordedValues.average()
+        val max = recordedValues.maxOrNull() ?: avg
+        val min = recordedValues.minOrNull() ?: avg
+        val formatter = DateTimeFormatter.ISO_INSTANT
+
+        val csvContent = buildString {
+            appendLine("session_id,time_started,user_id,avg_rate,max_rate,min_rate")
+            appendLine("$sessionId,${formatter.format(start)},$userId,$avg,$max,$min")
+        }
+
+        val file = File(context.cacheDir, "heart_session_$sessionId.csv")
+        file.writeText(csvContent)
+        return file
+    }
+}

--- a/app/src/main/java/org/reidlab/frontend/data/HeartRateSessionManager.kt
+++ b/app/src/main/java/org/reidlab/frontend/data/HeartRateSessionManager.kt
@@ -5,9 +5,15 @@ import java.io.File
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import java.net.HttpURLConnection
+import java.net.URL
+import java.io.DataOutputStream
+import android.util.Log
+
+
 
 class HeartRateSessionManager(private val context: Context) {
-    private val recordedValues = mutableListOf<Double>()
+    private val recordedValues = mutableListOf<Int>()
     private var startTime: Instant? = null
     private val sessionId: String = UUID.randomUUID().toString()
 
@@ -16,26 +22,70 @@ class HeartRateSessionManager(private val context: Context) {
         startTime = Instant.now()
     }
 
-    fun record(value: Double) {
+    fun record(value: Int) {
+        Log.d("SessionManager", "Recording HR value: $value")
         recordedValues.add(value)
     }
 
     fun stopAndExportCsv(userId: Int = 1): File? {
         val start = startTime ?: return null
         if (recordedValues.isEmpty()) return null
-
         val avg = recordedValues.average()
         val max = recordedValues.maxOrNull() ?: avg
         val min = recordedValues.minOrNull() ?: avg
         val formatter = DateTimeFormatter.ISO_INSTANT
 
         val csvContent = buildString {
-            appendLine("session_id,time_started,user_id,avg_rate,max_rate,min_rate")
-            appendLine("$sessionId,${formatter.format(start)},$userId,$avg,$max,$min")
+            appendLine("time_started,user_id,avg_rate,max_rate,min_rate")
+            appendLine("${formatter.format(start)},$userId,$avg,$max,$min")
         }
 
         val file = File(context.cacheDir, "heart_session_$sessionId.csv")
         file.writeText(csvContent)
+
+        android.util.Log.d("CSV_EXPORT", "CSV written to: ${file.absolutePath}")
+        android.util.Log.d("CSV_EXPORT", "File exists: ${file.exists()}")
+
         return file
     }
+
+    fun uploadCsvToServer(file: File, endpointUrl: String, onComplete: (Boolean, String) -> Unit) {
+    Thread {
+        try {
+            val boundary = "Boundary-${System.currentTimeMillis()}"
+            val connection = URL(endpointUrl).openConnection() as HttpURLConnection
+
+            connection.apply {
+                requestMethod = "POST"
+                doOutput = true
+                setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+            }
+
+            val outputStream = DataOutputStream(connection.outputStream)
+            val fileName = file.name
+
+            // Write form data headers
+            outputStream.writeBytes("--$boundary\r\n")
+            outputStream.writeBytes("Content-Disposition: form-data; name=\"heartRateFile\"; filename=\"$fileName\"\r\n")
+            outputStream.writeBytes("Content-Type: text/csv\r\n\r\n")
+
+            // Write file content
+            outputStream.write(file.readBytes())
+            outputStream.writeBytes("\r\n--$boundary--\r\n")
+            outputStream.flush()
+            outputStream.close()
+
+            val responseCode = connection.responseCode
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                onComplete(true, "Upload successful")
+            } else {
+                onComplete(false, "Upload failed: HTTP $responseCode")
+            }
+
+        } catch (e: Exception) {
+            onComplete(false, "Upload error: ${e.message}")
+        }
+    }.start()
+}
+
 }

--- a/app/src/main/java/org/reidlab/frontend/presentation/HeartRateScreen.kt
+++ b/app/src/main/java/org/reidlab/frontend/presentation/HeartRateScreen.kt
@@ -50,6 +50,8 @@ import androidx.wear.compose.material.CircularProgressIndicator
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
+import org.reidlab.frontend.data.HeartRateSessionManager
+
 
 
 // Zone colors based on:
@@ -186,6 +188,10 @@ fun HeartRateScreen(
     }
 
     val context = LocalContext.current
+
+    // Initiate sessionManager for data management
+    val sessionManager = remember { HeartRateSessionManager(context) }
+
     val vibrator = remember {
         context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?
     }
@@ -231,6 +237,19 @@ fun HeartRateScreen(
             }
         }
         previousZone = currentZone // Update previous zone *after* checking entry condition
+    }
+
+    // Logging HR to session manager
+    if (isDataActuallyAvailable && activeHrInt != null && isTimerRunning) {
+        sessionManager.record(activeHrInt)
+    }
+
+    LaunchedEffect(isTimerRunning) {
+        if (isTimerRunning) {
+            sessionManager.startSession()
+        } else {
+            sessionManager.stopAndExportCsv()
+        }   
     }
 
     LaunchedEffect(currentZone, isHapticFeedbackEnabled) { // Keyed on zone and setting

--- a/app/src/main/java/org/reidlab/frontend/presentation/HeartRateScreen.kt
+++ b/app/src/main/java/org/reidlab/frontend/presentation/HeartRateScreen.kt
@@ -51,9 +51,12 @@ import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import org.reidlab.frontend.data.HeartRateSessionManager
+import androidx.compose.runtime.setValue // Add this import
+import androidx.compose.runtime.getValue // Add this import
+import androidx.compose.runtime.mutableStateOf // Add this import
+import androidx.compose.runtime.remember // Add this import
+import androidx.wear.compose.material.Scaffold // Ensure Scaffold is imported
 import android.util.Log
-
-
 
 
 // Zone colors based on:
@@ -125,6 +128,12 @@ fun HeartRateScreen(
     onStopTimer: () -> Unit,
     birthDate: LocalDate?
 ) {
+
+    var showSessionCompleteDialog by remember { mutableStateOf(false) }
+    val handleStopTimerClick = {
+        onStopTimer() // Call the original function to stop the timer logic
+        showSessionCompleteDialog = true // Set state to show the dialog
+    }
     // Collect State from ViewModel
     val uiState by measureDataViewModel.uiState
     val availability by measureDataViewModel.availability
@@ -307,7 +316,7 @@ fun HeartRateScreen(
                 isTimerRunning = isTimerRunning,
                 elapsedTimeMillis = elapsedTimeMillis,
                 showMilliseconds = showMilliseconds,
-                onStopTimer = onStopTimer
+                onStopTimer = handleStopTimerClick
             )
         } else {
             // Render UI based on Real Data State (UiState, availability, etc.)
@@ -337,10 +346,17 @@ fun HeartRateScreen(
                         isTimerRunning = isTimerRunning,
                         elapsedTimeMillis = elapsedTimeMillis,
                         showMilliseconds = showMilliseconds,
-                        onStopTimer = onStopTimer
+                        onStopTimer = handleStopTimerClick
                     )
                 }
             }
+            SessionCompleteDialog(
+                showDialog = showSessionCompleteDialog, // Pass the state directly
+                onDismissRequest = { showSessionCompleteDialog = false }, // Hide on dismiss
+                onAcceptClick = { showSessionCompleteDialog = false }    // Hide on accept click
+                // Optionally add modifiers here if needed:
+                // modifier = Modifier.padding(bottom = 10.dp)
+            )
         }
     }
 }

--- a/app/src/main/java/org/reidlab/frontend/presentation/SettingsScreen.kt
+++ b/app/src/main/java/org/reidlab/frontend/presentation/SettingsScreen.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -33,6 +36,7 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
+import org.reidlab.frontend.presentation.SessionCompleteDialog
 import org.reidlab.frontend.R
 
 
@@ -50,6 +54,7 @@ fun SettingsScreen(
     isHapticFeedbackEnabled: Boolean,
     onToggleHapticFeedback: (Boolean) -> Unit
 ) {
+    var showSessionCompleteDialog by remember { mutableStateOf(false) }
     // Add ScrollState and FocusRequester
     val scrollState = rememberScrollState()
     val focusRequester = remember { FocusRequester() }
@@ -92,7 +97,12 @@ fun SettingsScreen(
 
             // Start/Stop Button
             Button(
-                onClick = { if (isTimerRunning) onStopTimer() else onStartTimer() },
+                onClick = { if (isTimerRunning) {
+                    onStopTimer()
+                    showSessionCompleteDialog = true
+                } else {
+                    onStartTimer()
+                } },
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = if (isTimerRunning) MaterialTheme.colors.error else Color(0xFFAAE0FA),
@@ -210,5 +220,10 @@ fun SettingsScreen(
             // Add some end padding so the button isn't cut off
             Spacer(Modifier.height(35.dp))
         }
+        SessionCompleteDialog(
+            showDialog = showSessionCompleteDialog, // Control visibility with state
+            onDismissRequest = { showSessionCompleteDialog = false }, // Hide on dismiss
+            onAcceptClick = { showSessionCompleteDialog = false }    // Hide on accept
+        )
     }
 }

--- a/app/src/main/java/org/reidlab/frontend/presentation/TimerStopDialog.kt
+++ b/app/src/main/java/org/reidlab/frontend/presentation/TimerStopDialog.kt
@@ -1,0 +1,86 @@
+package org.reidlab.frontend.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.dialog.Dialog
+
+
+@Composable
+fun SessionCompleteDialog(
+    // Add showDialog parameter to control visibility from the caller
+    showDialog: Boolean,
+    onDismissRequest: () -> Unit,
+    onAcceptClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Dialog(
+        showDialog = showDialog,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+        scrollState = null,
+    ) {
+        // Dialog content
+        Column (
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 10.dp, horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Spacer(Modifier.height(15.dp))
+            Text (
+                text = "Session Complete!",
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                style = MaterialTheme.typography.title3,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text (
+                text = "CSV now available to pulled from the watch.",
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.body1,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Button (
+                onClick = onAcceptClick,
+                shape = CircleShape,
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFFAAE0FA)
+                ),
+                modifier = Modifier.size(ButtonDefaults.DefaultButtonSize)
+            ) {
+                Icon (
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = "Accept",
+                    tint = Color.Black,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .wrapContentSize(align = Alignment.Center)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
I finished exporting the heart rate CSV and uploading it to the database. It works in the android studio emulator, so I assume it works on the actual watch too. The changes are mainly in the HeartRateScreen.kt and HeartRateSessionManager.kt, but I also had to change the AndroidManifest.xml to permit the emulator/watch to access the internet. 

Right now, it is working on the assumption the heart rate session is happening at the same time as a mantis session, so the session_id it inherits is just the most recent one for the mantis sessions. In other words, when you stop the timer, it will upload the heart rate CSV and inherit the most recent session_id in the mantis_data_sessions table. This works fine for our purposes, but I want it to be documented that it is only loosely overlaying. There is nothing stopping the user of starting 5 heart rate sessions by starting and stopping the timer and inherit the same session_id (the most recent one in the mantis_data_sessions table).

Other than that questionable structure, it works. And it won't break anything in the worst case scenario (the user wants to spam the heart rate timer), just kind of populates all the sessions on the most recent mantis session. That is something that can be reviewed in the future. 

If you have any other questions ping me in teams.